### PR TITLE
Expose APRS server in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Use the following command to print the gateway's info and version.
 !version
 ```
 
+**Find nearby APRS stations:**
+
+Use the following command to list the 10 closest APRS stations based on your node's current position.
+
+```
+!stations
+```
+
 ## Installation, Configuration, and Running
 
 ```console

--- a/src/aprstastic/_aprs_client.py
+++ b/src/aprstastic/_aprs_client.py
@@ -19,10 +19,12 @@ class APRSClient(object):
     Maybe we will implement our own one day!
     """
 
-    def __init__(self, login: str, passcode: str, filters: None):
+    def __init__(self, login: str, passcode: str, host: str, port: int, filters: None):
         super().__init__()
         self._login = login
         self._passcode = passcode
+        self._host = host
+        self._port = port
         self._filters = filters
         self._aprs = None
         self._rx_queue: Queue = Queue()
@@ -96,7 +98,7 @@ class APRSClient(object):
 
     def _rx_thread_body(self) -> None:
         try:
-            self._aprs = aprslib.IS(self._login, passwd=self._passcode, port=14580)
+            self._aprs = aprslib.IS(self._login, passwd=self._passcode, host=self._host, port=self._port)
             assert self._aprs is not None
             if self._filters is not None:
                 self._aprs.set_filter(self._filters)

--- a/src/aprstastic/_config_const.py
+++ b/src/aprstastic/_config_const.py
@@ -29,6 +29,10 @@ aprsis_filter_distance_km: 80
 aprsis_station_max_age_hours: 6
 
 
+# APRS station distance units for !stations (km or mi)
+aprsis_station_distance_units: km
+
+
 # Maximum length of an APRS text message. 
 # If null, or commented out, default to 67 as per APRS specification
 # max_aprs_message_length: 128

--- a/src/aprstastic/_config_const.py
+++ b/src/aprstastic/_config_const.py
@@ -12,6 +12,11 @@ call_sign: N0CALL
 aprsis_passcode: 12345 
 
 
+# APRS-IS Server Connection Settings
+#aprsis_host: rotate.aprs.net
+#aprsis_port: 14580
+
+
 # Maximum length of an APRS text message. 
 # If null, or commented out, default to 67 as per APRS specification
 # max_aprs_message_length: 128

--- a/src/aprstastic/_config_const.py
+++ b/src/aprstastic/_config_const.py
@@ -17,12 +17,15 @@ aprsis_passcode: 12345
 # max_aprs_message_length: 128
 
 
-# Only serial devices are supported right now. 
-# If 'device' is null (or commented out), an attempt will be made to 
-# detected it automatically.
+# Meshtastic interface options:
+#   type: serial (default) or tcp
+#   serial: specify 'device' or leave blank for auto-detect
+#   tcp: set 'host' (and optional 'port', default 4403)
 meshtastic_interface: 
    type: serial
 #  device: /dev/ttyACM0
+#  host: 192.168.1.50
+#  port: 4403
 
 
 # Beacon new registrations to APRS-IS to facilitate discovery

--- a/src/aprstastic/_config_const.py
+++ b/src/aprstastic/_config_const.py
@@ -17,6 +17,18 @@ aprsis_passcode: 12345
 #aprsis_port: 14580
 
 
+# APRS-IS Range Filter (optional)
+# Specify a fixed location (latitude/longitude) and range to receive nearby station positions.
+# If latitude/longitude are omitted, the gateway beacon location will be used if provided.
+#aprsis_filter_latitude: 47.6205063
+#aprsis_filter_longitude: -122.3518523
+aprsis_filter_distance_km: 80
+
+
+# APRS station cache (hours)
+aprsis_station_max_age_hours: 6
+
+
 # Maximum length of an APRS text message. 
 # If null, or commented out, default to 67 as per APRS specification
 # max_aprs_message_length: 128

--- a/src/aprstastic/_gateway.py
+++ b/src/aprstastic/_gateway.py
@@ -134,9 +134,13 @@ class Gateway(object):
 
         # Connect to APRS IS
         aprsis_passcode = self._config.get("aprsis_passcode")
+        aprsis_host = self._config.get("aprsis_host", "rotate.aprs.net")
+        aprsis_port = self._config.get("aprsis_port", 14580)
         self._aprs_client = APRSClient(
             self._gateway_call_sign,
             aprsis_passcode,
+            aprsis_host,
+            aprsis_port,
             "g/" + "/".join(self._filtered_call_signs),
         )
 

--- a/src/aprstastic/_gateway.py
+++ b/src/aprstastic/_gateway.py
@@ -14,6 +14,7 @@ import os
 import traceback
 import meshtastic.stream_interface
 import meshtastic.serial_interface
+import meshtastic.tcp_interface
 from datetime import datetime
 from meshtastic.util import findPorts
 
@@ -64,6 +65,7 @@ class Gateway(object):
     def __init__(self, config):
         self._config = config
         self._start_time = None
+        self._meshtastic_interface_config = config.get("meshtastic_interface") or {}
 
         self._gateway_id = None
         self._gateway_call_sign = None
@@ -91,9 +93,7 @@ class Gateway(object):
         self._start_time = time.time()
 
         # Connect to the Meshtastic device
-        device = self._config.get("meshtastic_interface", {}).get("device")
-
-        self._interface = self._get_interface(device)
+        self._interface = self._get_interface(self._meshtastic_interface_config)
         if self._interface is None:
             raise ValueError("No meshtastic device detected or specified.")
 
@@ -158,11 +158,11 @@ class Gateway(object):
             ############################
             reconnect = False
 
-            # Periodically check on the state of the device serial connection
+            # Periodically check on the state of the device connection
             if now > self._next_serial_check_time:
                 self._next_serial_check_time = now + SERIAL_WATCHDOG_INTERVAL
-                if self._interface.stream is None or not self._interface.stream.is_open:
-                    logger.warn("Serial connection is not open.")
+                if not self._is_interface_connected():
+                    logger.warn("Meshtastic connection is not open.")
                     reconnect = True
 
             # Check if the Meshtastic device has gone silent a while
@@ -183,7 +183,9 @@ class Gateway(object):
                 try:
                     if pubsub.pub.isSubscribed(on_recv, MQTT_TOPIC):
                         pubsub.pub.unsubscribe(on_recv, MQTT_TOPIC)
-                    self._interface = self._get_interface(device)
+                    self._interface = self._get_interface(
+                        self._meshtastic_interface_config
+                    )
                     if self._interface is not None:
                         pubsub.pub.subscribe(on_recv, MQTT_TOPIC)
                 except Exception as e:
@@ -244,24 +246,58 @@ class Gateway(object):
             time.sleep(0.001)
 
     def _get_interface(
-        self, device=None
+        self, interface_config=None
     ) -> meshtastic.stream_interface.StreamInterface:
-        if device is None:
-            ports = meshtastic.util.findPorts(True)
-            if len(ports) == 1:
-                device = ports[0]
-            else:
-                logger.error(
-                    "Please specify the correct serial port in 'aprstastic.yaml'. "
-                    f"Possible values include: {ports}"
-                )
-                return None
-        if device is not None:
+        config = interface_config or {}
+        interface_type = (config.get("type") or "serial").lower()
+
+        if interface_type == "serial":
+            device = config.get("device")
+            if device is None:
+                ports = findPorts(True)
+                if len(ports) == 1:
+                    device = ports[0]
+                else:
+                    logger.error(
+                        "Please specify the correct serial port in 'aprstastic.yaml'. "
+                        f"Possible values include: {ports}"
+                    )
+                    return None
             dev = meshtastic.serial_interface.SerialInterface(device)
-            logger.info(f"Connected to: {device}")
+            logger.info(f"Connected to serial device: {device}")
             return dev
-        else:
-            return None
+
+        if interface_type == "tcp":
+            host = config.get("host") or "localhost"
+            port = config.get("port") or meshtastic.tcp_interface.DEFAULT_TCP_PORT
+            dev = meshtastic.tcp_interface.TCPInterface(
+                hostname=host, portNumber=int(port)
+            )
+            logger.info(f"Connected to TCP host: {host}:{port}")
+            return dev
+
+        logger.error(
+            f"Unsupported meshtastic_interface type '{interface_type}'. "
+            "Valid values are 'serial' and 'tcp'."
+        )
+        return None
+
+    def _is_interface_connected(self):
+        if self._interface is None:
+            return False
+
+        stream = getattr(self._interface, "stream", None)
+        if stream is not None and hasattr(stream, "is_open"):
+            try:
+                return stream.is_open
+            except Exception:
+                return False
+
+        socket_obj = getattr(self._interface, "socket", None)
+        if socket_obj is not None:
+            return True
+
+        return True
 
     def _process_meshtastic_packet(self, packet):
         self._last_meshtastic_packet_time = time.time()


### PR DESCRIPTION
This exposes the APRS-IS server and port in the config file so a custom server can be used. If nothing is entered, the default is used.